### PR TITLE
More features!

### DIFF
--- a/lib/highlight-selected.coffee
+++ b/lib/highlight-selected.coffee
@@ -21,6 +21,19 @@ module.exports =
     highlightBackground:
       type: 'boolean'
       default: false
+    searchOnPartialWords:
+      type: 'boolean'
+      default: false
+    searchAnyCharacter:
+      type: 'boolean'
+      default: false
+    highlightInOtherPanes:
+      type: 'boolean'
+      default: false
+    highlightStop:
+      type: 'integer'
+      default: 200
+      description: 'Will stop highlighting after this many have been found'
     minimumLength:
       type: 'integer'
       default: 0

--- a/lib/highlighted-status-view.coffee
+++ b/lib/highlighted-status-view.coffee
@@ -8,7 +8,11 @@ class HighlightedStatusView extends HTMLDivElement
     @appendChild(@element)
 
   setCount: (@count) ->
-    @element.textContent = 'Found: ' + @count
+    limit = atom.config.get('selection-highlight.highlightStop')
+    s = '' + @count
+    if limit < @count
+      s = limit + '/' + @count
+    @element.textContent = 'Found: ' + s
 
   attach: ->
     if @statusBar?


### PR DESCRIPTION
Hi, I found this useful but saw some things that could be added. By default it works nearly the same as the original, and all options can be turned on or off in the settings.

Search on partial words: sometimes it is useful to search for just part of a word.
Search any character: for instance, allows searching for "[i]"
Highlight in other panes: as it says. I am quite pleased with this one.
Highlight stop: stops highlighting after a given amount have been found. If it goes over the limit the status bar will say "found limit / @count" instead of "found @count" Mostly for when Search any character is on and you selected a single space in a very large file, it can lag a bit.

First time using coffee script so it was neat modifying this. Let me know if there is anything I should do.